### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ Mounting NFS in a Deployment
     Now that you have Rancher up and running, it's very easy to create new clusters and import
     existing clusters.
 
-<a href="install/InstallRKEfromRancher">Install Downstream RKE Cluster from Rancher</a>
+<a href="install/InstallRKEfromRancher.md">Install Downstream RKE Cluster from Rancher</a>
 
-<a href="install/ImportClusterRancher">Import existing Downstream Cluster</a>
+<a href="install/ImportClusterRancher.md">Import existing Downstream Cluster</a>
 
 
 ## Deployments


### PR DESCRIPTION
add .md file extension to both links at "adding downstream clusters"  otherwise the article page will not be found.
.md only can be left off in the link, if the target is a folder with a README.md