### PR TITLE
PR: Update MetalLB installation guide to v0.13.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Install K3s on Raspberry Pi
 
 ### Networking
 
-   <a href="install/metalLB">Install and Configure MetalLB> - LoadBalancer that allows you to define a pool(s) of local IP addresses that can be automatically assigned/used by Applications deployed in Kubernetes 
+   <a href="install/metalLB">Install and Configure MetalLB</a> - LoadBalancer that allows you to define a pool(s) of local IP addresses that can be automatically assigned/used by Applications deployed in Kubernetes 
 
    <a href="install/traefik/README.md">Install and configure Traefik (on k3s)</a> - This lab will show you how to create different type of Ingress rules using a few different sample applications
 

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Install K3s on Raspberry Pi
 
 ### Networking
 
-   <a href="install/metalLB/README.md">Install and Configure MetalLB (on k3s)</a> - LoadBalancer that allows you to define a pool(s) of local IP addresses that can be automatically assigned/used by Applications deployed in Kubernetes 
+   <a href="install/metalLB">Install and Configure MetalLB> - LoadBalancer that allows you to define a pool(s) of local IP addresses that can be automatically assigned/used by Applications deployed in Kubernetes 
 
    <a href="install/traefik/README.md">Install and configure Traefik (on k3s)</a> - This lab will show you how to create different type of Ingress rules using a few different sample applications
 

--- a/install/metalLB/README.md
+++ b/install/metalLB/README.md
@@ -113,3 +113,10 @@ Accept-Language: en-us
 Connection: keep-alive
 Upgrade-Insecure-Requests: 1
 ```
+
+
+### 4) Clean Up
+
+```console
+kubectl delete -f https://raw.githubusercontent.com/SUSE/suse-at-home/main/install/metalLB/whoami-deploy.yaml
+```

--- a/install/metalLB/README.md
+++ b/install/metalLB/README.md
@@ -70,8 +70,28 @@ spec:
   - 10.0.0.100-10.0.0.120
 ```
 
-```
+```console
 kubectl apply -f metallb-config.yaml
+```
+
+### 3) Announce the service IPs
+The last step is to configure how MetalLB annouces the service. The simplest method is is to respond to ARP requests.   
+Make sure `spec.ipAddressPools` selector selects the correct IPAddressPool resource.
+[Read more](https://metallb.universe.tf/configuration/) about diffrent ways announce service IP.
+
+```yaml
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: example
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - first-pool
+```
+
+```console
+kubectl apply -f metallb-L2Advert.yaml
 ```
 
 # Testing MetalLB

--- a/install/metalLB/README.md
+++ b/install/metalLB/README.md
@@ -18,10 +18,39 @@ curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE=0644 sh -s - --disable=traefi
 
 # Install MetalLB     
 
+### 1) Install MetalLB 
 
-### 1) Create a namespace for Metal LB
-```console
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.10.2/manifests/namespace.yaml
+```cosnole
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.4/config/manifests/metallb-native.yaml
+```
+Example
+```
+namespace/metallb-system configured
+customresourcedefinition.apiextensions.k8s.io/addresspools.metallb.io created
+customresourcedefinition.apiextensions.k8s.io/bfdprofiles.metallb.io created
+customresourcedefinition.apiextensions.k8s.io/bgpadvertisements.metallb.io created
+customresourcedefinition.apiextensions.k8s.io/bgppeers.metallb.io created
+customresourcedefinition.apiextensions.k8s.io/communities.metallb.io created
+customresourcedefinition.apiextensions.k8s.io/ipaddresspools.metallb.io created
+customresourcedefinition.apiextensions.k8s.io/l2advertisements.metallb.io created
+serviceaccount/controller created
+serviceaccount/speaker created
+Warning: policy/v1beta1 PodSecurityPolicy is deprecated in v1.21+, unavailable in v1.25+
+podsecuritypolicy.policy/controller created
+podsecuritypolicy.policy/speaker created
+role.rbac.authorization.k8s.io/controller created
+role.rbac.authorization.k8s.io/pod-lister created
+clusterrole.rbac.authorization.k8s.io/metallb-system:controller created
+clusterrole.rbac.authorization.k8s.io/metallb-system:speaker created
+rolebinding.rbac.authorization.k8s.io/controller created
+rolebinding.rbac.authorization.k8s.io/pod-lister created
+clusterrolebinding.rbac.authorization.k8s.io/metallb-system:controller created
+clusterrolebinding.rbac.authorization.k8s.io/metallb-system:speaker created
+secret/webhook-server-cert created
+service/webhook-service created
+deployment.apps/controller created
+daemonset.apps/speaker created
+validatingwebhookconfiguration.admissionregistration.k8s.io/metallb-webhook-configuration created
 ```
 
 ### 2) Create a metallb-config.yaml file
@@ -31,49 +60,23 @@ Edit or create a `metallb-config.yaml` with the following entries
 *Note this example will give the addresses `10.0.0.100-120` to the LoadBalancer
 
 ```yaml
-apiVersion: v1
-kind: ConfigMap
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
 metadata:
+  name: first-pool
   namespace: metallb-system
-  name: config
-data:
-  config: |
-    address-pools:
-    - name: default
-      protocol: layer2
-      addresses:
-      - 10.0.0.100-10.0.0.120
+spec:
+  addresses:
+  - 10.0.0.100-10.0.0.120
 ```
 
 ```
 kubectl apply -f metallb-config.yaml
 ```
-### 3) Download and deploy metallb.yaml 
 
-```
-kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.10.2/manifests/metallb.yaml
-```
-Example
-```
-podsecuritypolicy.policy/controller created
-podsecuritypolicy.policy/speaker created
-serviceaccount/controller created
-serviceaccount/speaker created
-clusterrole.rbac.authorization.k8s.io/metallb-system:controller created
-clusterrole.rbac.authorization.k8s.io/metallb-system:speaker created
-role.rbac.authorization.k8s.io/config-watcher created
-role.rbac.authorization.k8s.io/pod-lister created
-clusterrolebinding.rbac.authorization.k8s.io/metallb-system:controller created
-clusterrolebinding.rbac.authorization.k8s.io/metallb-system:speaker created
-rolebinding.rbac.authorization.k8s.io/config-watcher created
-rolebinding.rbac.authorization.k8s.io/pod-lister created
-daemonset.apps/speaker created
-deployment.apps/controller created
-```
+# Testing MetalLB
 
-# Testing Metal LB
-
-### 1) Deploy whoami app using Metallb
+### 1) Deploy whoami app using MetalLB
 ```console
 kubectl apply -f https://raw.githubusercontent.com/SUSE/suse-at-home/main/install/metalLB/whoami-deploy.yaml
 ```

--- a/install/metalLB/README.md
+++ b/install/metalLB/README.md
@@ -9,28 +9,28 @@ At the end of the Lab you will have:
 - K3s - traefik and klipper (servicelb) disabled (see below for instructions)
 
 
-### K3s Installs Traefik 1.8) by default.  You can stop Traefik from installing with '--disable=traefik' during your k3s install or delete the helm deployment. You also need to disable the service loadbalancer (klipper) using '--disable=servicelb'
+> K3s Installs Traefik 1.8) by default.  You can stop Traefik from installing with '--disable=traefik' during your k3s install or delete the helm deployment. You also need to disable the service loadbalancer (klipper) using '--disable=servicelb'
   
   For Example 
-
-    curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE=0644 sh -s - --disable=traefik --disable=servicelb
-
+```
+curl -sfL https://get.k3s.io | K3S_KUBECONFIG_MODE=0644 sh -s - --disable=traefik --disable=servicelb
+```
 
 # Install MetalLB     
 
 
 ### 1) Create a namespace for Metal LB
-```
+```console
 kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.10.2/manifests/namespace.yaml
 ```
 
 ### 2) Create a metallb-config.yaml file
-Ensure the addresses match the available addresses in your configuration
-Edit or create a metallb-config.yml with the following entries
+Ensure the addresses match the available addresses in your configuration.
+Edit or create a `metallb-config.yaml` with the following entries
 
-*Note this example will give the addresses 10.0.0.100-120 to the LoadBalancer
+*Note this example will give the addresses `10.0.0.100-120` to the LoadBalancer
 
-```
+```yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -74,19 +74,20 @@ deployment.apps/controller created
 # Testing Metal LB
 
 ### 1) Deploy whoami app using Metallb
-```
-kubectl apply -f whoami-deploy.yaml
+```console
+kubectl apply -f https://raw.githubusercontent.com/SUSE/suse-at-home/main/install/metalLB/whoami-deploy.yaml
 ```
 
 ### 2) Locate the IP of the whoami service
 
-```
-kubectl get svc -A
+```console
+kubectl get svc -n who
 ```
 
 Example
 ```
-who    whoami  LoadBalancer   10.43.21.89     10.0.0.100   80:31247/TCP
+NAME     TYPE           CLUSTER-IP     EXTERNAL-IP    PORT(S)        AGE
+whoami   LoadBalancer   10.43.21.89    10.0.0.100     80:31247/TCP   21m
 ```
 
 ### 3) Test whoami App

--- a/install/metalLB/README.md
+++ b/install/metalLB/README.md
@@ -77,7 +77,7 @@ kubectl apply -f metallb-config.yaml
 ### 3) Announce the service IPs
 The last step is to configure how MetalLB annouces the service. The simplest method is is to respond to ARP requests.   
 Make sure `spec.ipAddressPools` selector selects the correct IPAddressPool resource.
-[Read more](https://metallb.universe.tf/configuration/) about diffrent ways announce service IP.
+[Read more](https://metallb.universe.tf/configuration/#announce-the-service-ips) about diffrent ways announce service IP.
 
 ```yaml
 apiVersion: metallb.io/v1beta1

--- a/install/metalLB/metallb-L2Advert.yaml
+++ b/install/metalLB/metallb-L2Advert.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: example
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+  - first-pool

--- a/install/metalLB/metallb-config.yaml
+++ b/install/metalLB/metallb-config.yaml
@@ -1,12 +1,8 @@
-apiVersion: v1
-kind: ConfigMap
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
 metadata:
+  name: first-pool
   namespace: metallb-system
-  name: config
-data:
-  config: |
-    address-pools:
-    - name: default
-      protocol: layer2
-      addresses:
-      - 10.0.0.100-10.0.0.120
+spec:
+  addresses:
+  - 10.0.0.100-10.0.0.120


### PR DESCRIPTION
Update MetalLB installation instruction to use the latest version v0.13.4, at the time of this writing. Also added a step to remove whoami deployment at the end.

(This started out as adding a missing letter.)